### PR TITLE
ci: fix missing PROD_HOST env in blue-green deployment step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -148,11 +148,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: production
-      url: http://${{ secrets.PROD_HOST }}
 
     steps:
       - name: 🚀 Deploy via SSH (Blue-Green)
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          PROD_HOST: ${{ secrets.PROD_HOST }}
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USER }}


### PR DESCRIPTION
- Add explicit `PROD_HOST` environment variable to SSH action.
