### PR TITLE
Adds hasProfile flag to User entity

### DIFF
--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/domain/model/aggregates/User.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/domain/model/aggregates/User.java
@@ -160,6 +160,7 @@ public class User extends AuditableAbstractAggregateRoot<User> {
                 .userId(this.getId())
                 .email(EmailAddress.toStringOrNull(this.email))
                 .username(Username.toStringOrNull(this.username))
+                .hasProfile(this.hasProfile)
                 .activationToken(activationToken)
                 .roles(this.roles.stream()
                         .map(role -> role.getName().name())

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/domain/model/events/UserCreatedEvent.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/domain/model/events/UserCreatedEvent.java
@@ -11,6 +11,7 @@ public class UserCreatedEvent extends ApplicationEvent {
     private final String userId;
     private final String email;
     private final String username;
+    private final Boolean hasProfile;
     private final String activationToken;
     private final List<String> roles;
     private final String districtId;
@@ -21,6 +22,7 @@ public class UserCreatedEvent extends ApplicationEvent {
         this.userId = builder.userId;
         this.email = builder.email;
         this.username = builder.username;
+        this.hasProfile = builder.hasProfile;
         this.activationToken = builder.activationToken;
         this.roles = builder.roles;
         this.districtId = builder.districtId;
@@ -36,6 +38,7 @@ public class UserCreatedEvent extends ApplicationEvent {
         private String userId;
         private String email;
         private String username;
+        private Boolean hasProfile;
         private String activationToken;
         private List<String> roles;
         private String districtId;
@@ -60,6 +63,11 @@ public class UserCreatedEvent extends ApplicationEvent {
 
         public Builder username(String username) {
             this.username = username;
+            return this;
+        }
+
+        public Builder hasProfile(Boolean hasProfile) {
+            this.hasProfile = hasProfile;
             return this;
         }
 

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/profile/application/internal/eventhandlers/UserCreatedEventHandler.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/profile/application/internal/eventhandlers/UserCreatedEventHandler.java
@@ -3,7 +3,6 @@ package com.ecolutions.platform.wastetrackplatform.profile.application.internal.
 import com.ecolutions.platform.wastetrackplatform.iam.domain.model.events.UserCreatedEvent;
 import com.ecolutions.platform.wastetrackplatform.profile.domain.model.commands.InitializeUserProfileCommand;
 import com.ecolutions.platform.wastetrackplatform.profile.domain.services.command.UserProfileCommandService;
-import com.ecolutions.platform.wastetrackplatform.shared.domain.model.valueobjects.Roles;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -19,16 +18,9 @@ public class UserCreatedEventHandler {
     @EventListener(UserCreatedEvent.class)
     @Async
     public void on(UserCreatedEvent event) {
-        var roles = event.getRoles().stream().map(Roles::fromString).toList();
+        if(!event.getHasProfile()) return;
 
-        var isSystemAdministrator = roles.contains(Roles.ROLE_SYSTEM_ADMINISTRATOR);
-        if (isSystemAdministrator) {return;}
-
-        var command = new InitializeUserProfileCommand(
-                event.getUserId(),
-                event.getEmail(),
-                event.getDistrictId()
-        );
+        var command = new InitializeUserProfileCommand(event.getUserId(), event.getEmail(), event.getDistrictId());
 
         userProfileCommandService.handle(command);
     }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/profile/application/internal/eventhandlers/UserCreatedEventHandler.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/profile/application/internal/eventhandlers/UserCreatedEventHandler.java
@@ -21,10 +21,8 @@ public class UserCreatedEventHandler {
     public void on(UserCreatedEvent event) {
         var roles = event.getRoles().stream().map(Roles::fromString).toList();
 
-        var isMunicipalAdministrator = roles.contains(Roles.ROLE_MUNICIPAL_ADMINISTRATOR);
-        var isDriver = roles.contains(Roles.ROLE_DRIVER);
-
-        if (!isMunicipalAdministrator && !isDriver) return;
+        var isSystemAdministrator = roles.contains(Roles.ROLE_SYSTEM_ADMINISTRATOR);
+        if (isSystemAdministrator) {return;}
 
         var command = new InitializeUserProfileCommand(
                 event.getUserId(),


### PR DESCRIPTION
Adds a `hasProfile` boolean field to the User entity and UserCreatedEvent to determine if a user profile should be initialized.

- Modifies the User entity to include a `hasProfile` field, which defaults to `false` and is updated based on the user's roles. Users with the `ROLE_SYSTEM_ADMINISTRATOR` role will not have a profile created.
- Updates the UserCreatedEvent to include the `hasProfile` field.
- Modifies the UserCreatedEventHandler to initialize a user profile only if the `hasProfile` flag is true.