### PR TITLE
feat(citizen): add email field to Citizen and InitializeCitizenCommand

### DIFF
--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/application/internal/eventhandlers/SignedUpEventHandler.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/application/internal/eventhandlers/SignedUpEventHandler.java
@@ -18,7 +18,7 @@ public class SignedUpEventHandler {
     @EventListener(SignedUpEvent.class)
     @Async
     public void on(SignedUpEvent event) {
-        var command = new InitializeCitizenCommand(event.getUserId());
+        var command = new InitializeCitizenCommand(event.getUserId(), event.getEmail());
         citizenCommandService.handle(command);
     }
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/domain/model/aggregates/Citizen.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/domain/model/aggregates/Citizen.java
@@ -26,11 +26,10 @@ public class Citizen extends AuditableAbstractAggregateRoot<Citizen> {
     private UserId userId;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "district_id", nullable = false))
+    @AttributeOverride(name = "value", column = @Column(name = "district_id"))
     private DistrictId districtId;
 
     @Embedded
-    @NotNull
     private FullName fullName;
 
     @Embedded
@@ -38,7 +37,7 @@ public class Citizen extends AuditableAbstractAggregateRoot<Citizen> {
     private EmailAddress email;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "phone_number", nullable = false, unique = true))
+    @AttributeOverride(name = "value", column = @Column(name = "phone_number", unique = true))
     private PhoneNumber phoneNumber;
 
     @Embedded
@@ -79,6 +78,7 @@ public class Citizen extends AuditableAbstractAggregateRoot<Citizen> {
     public Citizen(InitializeCitizenCommand command) {
         this();
         this.userId = UserId.of(command.userId());
+        this.email = new EmailAddress(command.email());
         this.status = CitizenStatus.INCOMPLETE;
     }
 

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/domain/model/commands/InitializeCitizenCommand.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/communityrelations/domain/model/commands/InitializeCitizenCommand.java
@@ -1,7 +1,8 @@
 package com.ecolutions.platform.wastetrackplatform.communityrelations.domain.model.commands;
 
 public record InitializeCitizenCommand(
-    String userId
+    String userId,
+    String email
 ) {
     public InitializeCitizenCommand {
         if (userId == null || userId.isBlank()) {


### PR DESCRIPTION
Include email as a required field in the Citizen aggregate and InitializeCitizenCommand record. Updated SignedUpEventHandler to pass email when initializing a citizen. Removed redundant null constraints for districtId and phoneNumber to align with updated requirements.
