### PR TITLE
Externalizes CORS configuration

### DIFF
--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/infrastructure/authorization/sfs/configuration/CorsProperties.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/infrastructure/authorization/sfs/configuration/CorsProperties.java
@@ -1,0 +1,37 @@
+package com.ecolutions.platform.wastetrackplatform.iam.infrastructure.authorization.sfs.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins = List.of();
+    private List<String> allowedMethods = List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS");
+    private List<String> allowedHeaders = List.of("*");
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    public List<String> getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    public void setAllowedMethods(List<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+}

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/infrastructure/authorization/sfs/configuration/WebSecurityConfiguration.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/iam/infrastructure/authorization/sfs/configuration/WebSecurityConfiguration.java
@@ -4,6 +4,7 @@ import com.ecolutions.platform.wastetrackplatform.iam.infrastructure.authorizati
 import com.ecolutions.platform.wastetrackplatform.iam.infrastructure.hashing.bcrypt.BCryptHashingService;
 import com.ecolutions.platform.wastetrackplatform.iam.infrastructure.tokens.jwt.BearerTokenService;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -25,23 +26,26 @@ import java.util.List;
 
 @Configuration
 @EnableMethodSecurity
+@EnableConfigurationProperties(CorsProperties.class)
 @Profile("!test")
 public class WebSecurityConfiguration {
     private final UserDetailsService userDetailsService;
     private final BearerTokenService tokenService;
     private final BCryptHashingService hashingService;
     private final AuthenticationEntryPoint unauthorizedRequestHandlerEntryPoint;
+    private final CorsProperties corsProperties;
 
     public WebSecurityConfiguration(
             @Qualifier("defaultUserDetailsService")
             UserDetailsService userDetailsService,
             BearerTokenService tokenService,
             BCryptHashingService hashingService,
-            AuthenticationEntryPoint unauthorizedRequestHandlerEntryPoint) {
+            AuthenticationEntryPoint unauthorizedRequestHandlerEntryPoint, CorsProperties corsProperties) {
         this.userDetailsService = userDetailsService;
         this.tokenService = tokenService;
         this.hashingService = hashingService;
         this.unauthorizedRequestHandlerEntryPoint = unauthorizedRequestHandlerEntryPoint;
+        this.corsProperties = corsProperties;
     }
 
     @Bean
@@ -81,9 +85,10 @@ public class WebSecurityConfiguration {
         // Cross-Origin Resource Sharing configuration
         http.cors(configurer -> configurer.configurationSource(_ -> {
             var cors = new CorsConfiguration();
-            cors.setAllowedOrigins(List.of("*"));
-            cors.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-            cors.setAllowedHeaders(List.of("*"));
+            cors.setAllowedOrigins(corsProperties.getAllowedOrigins());
+            cors.setAllowedMethods(corsProperties.getAllowedMethods());
+            cors.setAllowedHeaders(corsProperties.getAllowedHeaders());
+            cors.setAllowCredentials(true);
             return cors;
         }));
         // Cross-Site Request Forgery configuration

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/shared/infrastructure/communication/websockets/WebSocketConfig.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/shared/infrastructure/communication/websockets/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.ecolutions.platform.wastetrackplatform.shared.infrastructure.communication.websockets;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -8,7 +9,14 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@EnableConfigurationProperties(WebSocketProperties.class)
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final WebSocketProperties wsProperties;
+
+    public WebSocketConfig(WebSocketProperties wsProperties) {
+        this.wsProperties = wsProperties;
+    }
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableSimpleBroker("/topic");
@@ -18,6 +26,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:4200", "http://localhost:4300");
+                .setAllowedOriginPatterns(wsProperties.getAllowedOrigins().toArray(new String[0]));
     }
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/shared/infrastructure/communication/websockets/WebSocketProperties.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/shared/infrastructure/communication/websockets/WebSocketProperties.java
@@ -1,0 +1,20 @@
+package com.ecolutions.platform.wastetrackplatform.shared.infrastructure.communication.websockets;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.websocket")
+public class WebSocketProperties {
+
+    private List<String> allowedOrigins = List.of();
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,11 @@ mqtt.client.id=${MQTT_CLIENT_ID:waste-track-backend}
 mqtt.username=${MQTT_USERNAME:}
 mqtt.password=${MQTT_PASSWORD:}
 mqtt.subscribe.topics=${MQTT_SUBSCRIBE_TOPICS:cm/sensors/#}
+
+# CORS Configuration
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:4300}
+app.cors.allowed-methods=${CORS_ALLOWED_METHODS:GET,POST,PUT,DELETE,PATCH,OPTIONS}
+app.cors.allowed-headers=${CORS_ALLOWED_HEADERS:Authorization,Content-Type,Accept,X-Requested-With}
+
+# WebSocket CORS Configuration
+app.websocket.allowed-origins=${WS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:4300}


### PR DESCRIPTION
Externalizes CORS configuration for the application and WebSocket to allow easier management of allowed origins, methods, and headers via application properties.

- Introduces `CorsProperties` and `WebSocketProperties` to manage CORS configuration.
- Updates `WebSecurityConfiguration` to use `CorsProperties` for configuring CORS.
- Updates `WebSocketConfig` to use `WebSocketProperties` for configuring allowed origins.