### PR TITLE
Emits event when a waypoint is visited

### DIFF
--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/communicationhub/application/internal/eventhandlers/UserCreatedEventHandler.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/communicationhub/application/internal/eventhandlers/UserCreatedEventHandler.java
@@ -5,7 +5,6 @@ import com.ecolutions.platform.wastetrackplatform.communicationhub.domain.servic
 import com.ecolutions.platform.wastetrackplatform.iam.domain.model.events.UserCreatedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/application/internal/commandservices/ContainerCommandServiceImpl.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/application/internal/commandservices/ContainerCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.ecolutions.platform.wastetrackplatform.containermonitoring.applicati
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.aggregates.Container;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.CreateContainerCommand;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.DeleteContainerCommand;
+import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.EmptyContainerCommand;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.UpdateContainerCommand;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.valueobjects.DeviceIdentifier;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.valueobjects.SensorId;
@@ -97,5 +98,14 @@ public class ContainerCommandServiceImpl implements ContainerCommandService {
                 .orElseThrow(() -> new IllegalArgumentException("Container with ID " + command.containerId() + " not found."));
         containerRepository.delete(existingContainer);
         return true;
+    }
+
+    @Override
+    public Optional<Container> handle(EmptyContainerCommand command) {
+        var existingContainer = containerRepository.findById(command.containerId())
+                .orElseThrow(() -> new IllegalArgumentException("Container with ID " + command.containerId() + " not found."));
+        existingContainer.emptyContainer();
+        var updatedContainer = containerRepository.save(existingContainer);
+        return Optional.of(updatedContainer);
     }
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/application/internal/eventhandlers/WayPointAsVisitedEventHandler.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/application/internal/eventhandlers/WayPointAsVisitedEventHandler.java
@@ -1,0 +1,30 @@
+package com.ecolutions.platform.wastetrackplatform.containermonitoring.application.internal.eventhandlers;
+
+import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.EmptyContainerCommand;
+import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.services.command.ContainerCommandService;
+import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.events.WayPointAsVisitedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Service("WayPointAsVisitedEventHandler")
+public class WayPointAsVisitedEventHandler {
+    private final ContainerCommandService containerCommandService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WayPointAsVisitedEventHandler.class);
+
+    public WayPointAsVisitedEventHandler(ContainerCommandService containerCommandService) {
+        this.containerCommandService = containerCommandService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void on(WayPointAsVisitedEvent event) {
+        LOGGER.info("Handling WayPointAsVisitedEvent for waypoint: {} associated with container: {}", event.getWayPointId(), event.getContainerId());
+        var command = new EmptyContainerCommand(event.getContainerId());
+        containerCommandService.handle(command);
+    }
+}

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/model/aggregates/Container.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/model/aggregates/Container.java
@@ -151,4 +151,8 @@ public class Container extends AuditableAbstractAggregateRoot<Container> {
                 .occurredAt(LocalDateTime.now())
                 .build();
     }
+
+    public void emptyContainer() {
+        this.currentFillLevel = new CurrentFillLevel(0);
+    }
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/model/commands/EmptyContainerCommand.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/model/commands/EmptyContainerCommand.java
@@ -1,0 +1,9 @@
+package com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands;
+
+public record EmptyContainerCommand(String containerId) {
+    public EmptyContainerCommand {
+        if (containerId == null || containerId.isBlank()) {
+            throw new IllegalArgumentException("Container ID cannot be null or blank");
+        }
+    }
+}

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/services/command/ContainerCommandService.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/containermonitoring/domain/services/command/ContainerCommandService.java
@@ -2,6 +2,7 @@ package com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.se
 
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.aggregates.Container;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.CreateContainerCommand;
+import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.EmptyContainerCommand;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.UpdateContainerCommand;
 import com.ecolutions.platform.wastetrackplatform.containermonitoring.domain.model.commands.DeleteContainerCommand;
 
@@ -11,4 +12,5 @@ public interface ContainerCommandService {
     Optional<Container> handle(CreateContainerCommand command);
     Optional<Container> handle(UpdateContainerCommand command);
     Boolean handle(DeleteContainerCommand command);
+    Optional<Container> handle(EmptyContainerCommand command);
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/aggregates/Route.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/aggregates/Route.java
@@ -159,7 +159,7 @@ public class Route extends AuditableAbstractAggregateRoot<Route> {
         this.status = RouteStatus.COMPLETED;
     }
 
-    public void markWaypointAsVisited(String waypointId) {
+    public WayPoint markWaypointAsVisited(String waypointId) {
         WayPoint waypoint = waypoints.stream()
             .filter(wp -> wp.getId().equals(waypointId))
             .findFirst()
@@ -167,6 +167,7 @@ public class Route extends AuditableAbstractAggregateRoot<Route> {
 
         waypoint.markAsVisited();
         this.totalCompletedWaypoints++;
+        return waypoint;
     }
 
     public boolean canBeModified() {

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/entities/WayPoint.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/entities/WayPoint.java
@@ -2,6 +2,7 @@ package com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain
 
 import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.commands.CreateWayPointCommand;
 import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.commands.UpdateWayPointCommand;
+import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.events.WayPointAsVisitedEvent;
 import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.valueobjects.Priority;
 import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.valueobjects.PriorityLevel;
 import com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.valueobjects.WaypointStatus;
@@ -87,5 +88,13 @@ public class WayPoint extends AuditableModel {
             throw new IllegalStateException("Cannot update priority of non-pending waypoint");
         }
         this.priority = newPriority;
+    }
+
+    public WayPointAsVisitedEvent publishWaypointAsVisitedEvent() {
+        return WayPointAsVisitedEvent.builder()
+                .source(this)
+                .wayPointId(id)
+                .containerId(ContainerId.toStringOrNull(this.containerId))
+                .build();
     }
 }

--- a/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/events/WayPointAsVisitedEvent.java
+++ b/src/main/java/com/ecolutions/platform/wastetrackplatform/routeplanningexecution/domain/model/events/WayPointAsVisitedEvent.java
@@ -1,0 +1,48 @@
+package com.ecolutions.platform.wastetrackplatform.routeplanningexecution.domain.model.events;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class WayPointAsVisitedEvent extends ApplicationEvent {
+    private final String wayPointId;
+    private final String containerId;
+
+
+    private WayPointAsVisitedEvent(Builder builder) {
+        super(builder.source);
+        this.wayPointId = builder.wayPointId;
+        this.containerId = builder.containerId;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Object source;
+        private String wayPointId;
+        private String containerId;
+
+        private Builder() {}
+
+        public Builder source(Object source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder wayPointId(String wayPointId) {
+            this.wayPointId = wayPointId;
+            return this;
+        }
+
+        public Builder containerId(String containerId) {
+            this.containerId = containerId;
+            return this;
+        }
+
+        public WayPointAsVisitedEvent build() {
+            return new WayPointAsVisitedEvent(this);
+        }
+    }
+}


### PR DESCRIPTION
Emits a `WayPointAsVisitedEvent` when a waypoint is marked as visited on a route.

This allows other services to react to this event, such as emptying the container associated with the waypoint.

- Introduces the `WayPointAsVisitedEvent` and the logic to publish it when a waypoint is marked as visited.
- Implements the `EmptyContainerCommand` and its handling in the `ContainerCommandService`.
- Creates a `WayPointAsVisitedEventHandler` to process the waypoint collection events and trigger the `EmptyContainerCommand`.